### PR TITLE
Add missing npm deps, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This runs a Flask process, so you can add the typical flags such as setting a di
 ```sh
 $ git clone https://github.com/nat/openplayground
 $ cd app && npm install && npx parcel watch src/index.html --no-cache
-$ cd server && pip3 install -r requirements.txt && python app.py
+$ cd server && pip3 install -r requirements.txt && cd .. && python -m server.app
 ```
 
 ## Ideas for contributions

--- a/app/package.json
+++ b/app/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@parcel/compressor-brotli": "^2.8.3",
     "@parcel/compressor-gzip": "^2.8.3",
+    "@parcel/config-default": "^2.8.3",
     "@types/chroma-js": "^2.4.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
@@ -22,6 +23,7 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.2",
     "@radix-ui/react-checkbox": "^1.0.1",
+    "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.2",
     "@radix-ui/react-label": "^2.0.0",
     "@radix-ui/react-navigation-menu": "^1.1.1",


### PR DESCRIPTION
This pr fixes following error that occurs when running npx parcel watch src/index.html --no-cache
`Failed to resolve '@radix-ui/react-dialog' from './src/components/ui/right-sheet.tsx'`
`Cannot find module "@parcel/config-default"`

Fix error when execute python app.py under server folder.
`ModuleNotFoundError: No module named 'server'`