### PR TITLE
Let Error 404 redirect to 'index.html'

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -42,6 +42,11 @@ def serve(path):
 
     return send_from_directory(app.static_folder, path)
 
+@app.errorhandler(404)
+def page_not_found(i):
+    path = 'index.html'
+    return send_from_directory(app.static_folder, path)
+
 @app.before_request
 def before_request():
     g.global_state = app.config['GLOBAL_STATE']


### PR DESCRIPTION
# Issue
Going to a link that'll trigger the Error 404 (such as [https://nat.dev/304923940itrhdjwndw](https://nat.dev/304923940itrhdjwndw)) will leave you at a blank page, instead of telling you that it's a wrong path or giving any indication of any kind. 

<img width="679" alt="image" src="https://user-images.githubusercontent.com/112625750/229734988-7fa4a1e5-1bba-4d07-8bf0-06404a4447a1.png">

It even produces errors in the console:
```
o4504753889673216.ingest.sentry.io/api/4504753890918400/envelope/?sentry_key=ba8762f0657a48cbb62daf5f4b68cc91&sentry_version=7&sentry_client=sentry.javascript.react%2F7.39.0:1          
Failed to load resource: net::ERR_BLOCKED_BY_CLIENT

o4504753889673216.ingest.sentry.io/api/4504753890918400/envelope/?sentry_key=ba8762f0657a48cbb62daf5f4b68cc91&sentry_version=7&sentry_client=sentry.javascript.react%2F7.39.0:1          
Failed to load resource: net::ERR_BLOCKED_BY_CLIENT
```

## Intended Output
```py
if path == "" or not os.path.exists(app.static_folder + '/' + path):
        path = 'index.html'
```
This code intends that if the OS path doesn't exist - meaning that the file doesn't exist and the request is reaching the wrong location, and doesn't work. 

Change in code:
```diff
+ @app.errorhandler(404)
+ def page_not_found(i):
+     path = 'index.html'
+     return send_from_directory(app.static_folder, path)
```
I just added the index path on 404 error.
