### PR TITLE
Remove styles when pasting text

### DIFF
--- a/app/src/pages/playground.tsx
+++ b/app/src/pages/playground.tsx
@@ -286,6 +286,7 @@ class EditorWrapper extends React.Component {
         onChange={(editorState: any) => {
           setEditorState(editorState)
         }}
+        stripPastedStyles
       />
     )
   }


### PR DESCRIPTION
Fixed by stripping styles when text is pasted.
Resolves #1 

https://user-images.githubusercontent.com/47112778/229919856-5ed14c4c-b956-4039-b7ed-1fc9c8eb7f76.mp4

