### PR TITLE
Use evergreen Claude versions.

### DIFF
--- a/server/models.json
+++ b/server/models.json
@@ -607,7 +607,7 @@
     "requiresAPIKey": true,
     "remoteInference": true,
     "models": {
-      "claude-instant-v1.0": {
+      "claude-instant-v1": {
         "enabled": false,
         "status": "ready",
         "capabilities": [
@@ -662,7 +662,7 @@
           }
         }
       },
-      "claude-v1.2": {
+      "claude-v1": {
         "enabled": false,
         "status": "ready",
         "capabilities": [


### PR DESCRIPTION
Updates Claude model names to `claude-v1` and `claude-instant-v1` so that both pickup the latest compatible models. E.g. `claude-v1.3` is available as of today.