### PR TITLE
Use correct params for Anthropic models.

### DIFF
--- a/server/lib/inference/__init__.py
+++ b/server/lib/inference/__init__.py
@@ -606,10 +606,9 @@ class InferenceManager:
 
         response = c.completion_stream(
             prompt=f"{anthropic.HUMAN_PROMPT} {inference_request.prompt}{anthropic.AI_PROMPT}",
-            stopSequences=[anthropic.HUMAN_PROMPT] + inference_request.model_parameters['stopSequences'],
+            stop_sequences=[anthropic.HUMAN_PROMPT] + inference_request.model_parameters['stopSequences'],
             temperature=float(inference_request.model_parameters['temperature']),
-            topP=float(inference_request.model_parameters['topP']),
-            topK=int(inference_request.model_parameters['topK']),
+            top_p=float(inference_request.model_parameters['topP']),
             max_tokens_to_sample=inference_request.model_parameters['maximumLength'],
             model=inference_request.model_name,
             stream=True,

--- a/server/models.json
+++ b/server/models.json
@@ -504,9 +504,7 @@
       "claude-instant-v1": {
         "enabled": false,
         "status": "ready",
-        "capabilities": [
-          "logprobs"
-        ],
+        "capabilities": [],
         "parameters": {
           "temperature": {
             "value": 1,
@@ -529,27 +527,6 @@
               1
             ]
           },
-          "topK": {
-            "value": 1,
-            "range": [
-              1,
-              500
-            ]
-          },
-          "presencePenalty": {
-            "value": 1,
-            "range": [
-              0,
-              1
-            ]
-          },
-          "frequencyPenalty": {
-            "value": 1,
-            "range": [
-              0,
-              1
-            ]
-          },
           "stopSequences": {
             "value": [],
             "range": []
@@ -559,9 +536,7 @@
       "claude-v1": {
         "enabled": false,
         "status": "ready",
-        "capabilities": [
-          "logprobs"
-        ],
+        "capabilities": [],
         "parameters": {
           "temperature": {
             "value": 1,
@@ -581,27 +556,6 @@
             "value": 1,
             "range": [
               0.1,
-              1
-            ]
-          },
-          "topK": {
-            "value": 1,
-            "range": [
-              1,
-              500
-            ]
-          },
-          "presencePenalty": {
-            "value": 1,
-            "range": [
-              0,
-              1
-            ]
-          },
-          "frequencyPenalty": {
-            "value": 1,
-            "range": [
-              0,
               1
             ]
           },


### PR DESCRIPTION
Reference: https://console.anthropic.com/docs/api/reference

Changes:
- snake_case instead of camelCase
- no frequency or presence penalty or log probs
- remove top_k

For `top_k`, the Anthropic API defaults to disabled (rather than the value before this commit, which was 1). I don't see a way to express that in OpenPlayground currently, so removing it from the UI.